### PR TITLE
Add `tags` directive for statamic tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,50 @@ If you only wish to change the text without changing attributes you can also pas
 </div>
 ```
 
+### @tags
+
+*This is a blade directive that's only available if you use Statamic in your project.*  
+When you want to get data from Statamic, often you need to use the `Statamic::tag` functionality. The `@tags` directive wraps that up to be a little more concise.
+
+#### Usage
+
+This directive can be used in the following way:
+
+```blade
+@tags(['collection:products', 'taxonomy:types'])
+```
+
+This will give you camelCased variables called `$collectionProducts` and `$taxonomyTypes` that can then be used in your blade file.
+
+You can then also give it your own variable name and then send some params through, like this:
+
+```blade
+@tags([
+    'products' => 'collection:products',
+    'types' => ['taxonomy:types' => ['color:is' => 'red']],
+])
+```
+
+If you only want one tag with the camelCased name, you can ditch the array:
+
+```blade
+@tags('collection:products')
+```
+
+Finally, if you prefer having some explicitly named key/value pairs, you can even do this:
+
+```blade
+@tags([
+    'products' => [
+        'tag' => 'collection:products',
+    ],
+    'types' => [
+        'tag' => 'taxonomy:types',
+        'params' => ['color:is' => 'red'],
+    ],
+])
+```
+
 ## License
 
 GNU General Public License v3. Please see [License File](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If you only wish to change the text without changing attributes you can also pas
 ### @tags
 
 *This is a blade directive that's only available if you use Statamic in your project.*  
-When you want to get data from Statamic, often you need to use the `Statamic::tag` functionality. The `@tags` directive wraps that up to be a little more concise.
+When you want to get data from Statamic, you'll often find yourself needing to use the `Statamic::tag` functionality. The `@tags` directive wraps that up to be a little more concise.
 
 #### Usage
 
@@ -155,7 +155,7 @@ This directive can be used in the following way:
 
 This will give you camelCased variables called `$collectionProducts` and `$taxonomyTypes` that can then be used in your blade file.
 
-You can then also give it your own variable name and then send some params through, like this:
+You can also define your own variable names and then send some params through, like this:
 
 ```blade
 @tags([
@@ -164,7 +164,7 @@ You can then also give it your own variable name and then send some params throu
 ])
 ```
 
-If you only want one tag with the camelCased name, you can ditch the array:
+And if you only want one tag with the camelCased name, you can ditch the array:
 
 ```blade
 @tags('collection:products')

--- a/src/BladeDirectivesServiceProvider.php
+++ b/src/BladeDirectivesServiceProvider.php
@@ -68,7 +68,7 @@ class BladeDirectivesServiceProvider extends ServiceProvider
                         } else if (is_array(\$__value) && count(\$__value) == 1) {
                             \$__tag = array_keys(\$__value)[0];
                             \$__params = array_values(\$__value)[0];
-                        } else if (is_string(\$__value) {
+                        } else if (is_string(\$__value)) {
                             \$__tag = \$__value;
                             \$__params = [];
                         } else {
@@ -77,6 +77,7 @@ class BladeDirectivesServiceProvider extends ServiceProvider
                         \$__varName = is_string(\$__key) ? \$__key : camel_case(str_replace(':', '_', \$__tag));
                         \${\$__varName} = Statamic::tag(\$__tag)->params(\$__params)->fetch();
                     }
+                    unset(\$__tag, \$__params, \$__varName, \$__key, \$__value);
                 ?>";
             });
         }

--- a/src/BladeDirectivesServiceProvider.php
+++ b/src/BladeDirectivesServiceProvider.php
@@ -49,6 +49,33 @@ class BladeDirectivesServiceProvider extends ServiceProvider
 <?php \$attributes ??= new \\Illuminate\\View\\ComponentAttributeBag; ?>
 <?php \$attributes = \$attributes->exceptProps($expression); ?>";
         });
+
+        Blade::directive('tags', function ($expression) {
+            /**
+             * Use Statamic::tag() in a more convenient way
+             * Usage:
+             *  - @tags(['products' => ['collection:products' => ['type' => 'chair']]])
+             *  - @tags(['products' => 'collection:products'])
+             *  - @tags('collection:products')
+             * etc...
+             */
+            return "<?php
+                foreach(Arr::wrap($expression) as \$__key => \$__value) {
+                    if (is_array(\$__value) && count(\$__value) == 1) {
+                        \$__tag = array_keys(\$__value)[0];
+                        \$__params = array_values(\$__value)[0];
+                    } else if (is_array(\$__value)) {
+                        \$__tag = \$__value['tag'];
+                        \$__params = \$__value['params'] ?? [];
+                    } else {
+                        \$__tag = \$__value;
+                        \$__params = [];
+                    }
+                    \$__varName = is_string(\$__key) ? \$__key : camel_case(str_replace(':','_',\$__tag));
+                    \${\$__varName} = Statamic::tag(\$__tag)->params(\$__params)->fetch();
+                }
+            ?>";
+        });
     }
 
     public function boot()

--- a/src/BladeDirectivesServiceProvider.php
+++ b/src/BladeDirectivesServiceProvider.php
@@ -61,15 +61,17 @@ class BladeDirectivesServiceProvider extends ServiceProvider
              */
             return "<?php
                 foreach(Arr::wrap($expression) as \$__key => \$__value) {
-                    if (is_array(\$__value) && count(\$__value) == 1) {
-                        \$__tag = array_keys(\$__value)[0];
-                        \$__params = array_values(\$__value)[0];
-                    } else if (is_array(\$__value)) {
+                    if (is_array(\$__value) && in_array('tag', \$__value)) {
                         \$__tag = \$__value['tag'];
                         \$__params = \$__value['params'] ?? [];
-                    } else {
+                    } else if (is_array(\$__value) && count(\$__value) == 1) {
+                        \$__tag = array_keys(\$__value)[0];
+                        \$__params = array_values(\$__value)[0];
+                    } else if (is_string(\$__value) {
                         \$__tag = \$__value;
                         \$__params = [];
+                    } else {
+                        continue;
                     }
                     \$__varName = is_string(\$__key) ? \$__key : camel_case(str_replace(':','_',\$__tag));
                     \${\$__varName} = Statamic::tag(\$__tag)->params(\$__params)->fetch();

--- a/src/BladeDirectivesServiceProvider.php
+++ b/src/BladeDirectivesServiceProvider.php
@@ -50,34 +50,36 @@ class BladeDirectivesServiceProvider extends ServiceProvider
 <?php \$attributes = \$attributes->exceptProps($expression); ?>";
         });
 
-        Blade::directive('tags', function ($expression) {
-            /**
-             * Use Statamic::tag() in a more convenient way
-             * Usage:
-             *  - @tags(['products' => ['collection:products' => ['type' => 'chair']]])
-             *  - @tags(['products' => 'collection:products'])
-             *  - @tags('collection:products')
-             * etc...
-             */
-            return "<?php
-                foreach(Arr::wrap($expression) as \$__key => \$__value) {
-                    if (is_array(\$__value) && in_array('tag', \$__value)) {
-                        \$__tag = \$__value['tag'];
-                        \$__params = \$__value['params'] ?? [];
-                    } else if (is_array(\$__value) && count(\$__value) == 1) {
-                        \$__tag = array_keys(\$__value)[0];
-                        \$__params = array_values(\$__value)[0];
-                    } else if (is_string(\$__value) {
-                        \$__tag = \$__value;
-                        \$__params = [];
-                    } else {
-                        continue;
+        if (class_exists('Statamic\Statamic')) {
+            Blade::directive('tags', function ($expression) {
+                /**
+                 * Use Statamic::tag() in a more convenient way
+                 * Usage:
+                 *  - @tags(['products' => ['collection:products' => ['type' => 'chair']]])
+                 *  - @tags(['products' => 'collection:products'])
+                 *  - @tags('collection:products')
+                 * etc...
+                 */
+                return "<?php
+                    foreach (Arr::wrap($expression) as \$__key => \$__value) {
+                        if (is_array(\$__value) && in_array('tag', \$__value)) {
+                            \$__tag = \$__value['tag'];
+                            \$__params = \$__value['params'] ?? [];
+                        } else if (is_array(\$__value) && count(\$__value) == 1) {
+                            \$__tag = array_keys(\$__value)[0];
+                            \$__params = array_values(\$__value)[0];
+                        } else if (is_string(\$__value) {
+                            \$__tag = \$__value;
+                            \$__params = [];
+                        } else {
+                            continue;
+                        }
+                        \$__varName = is_string(\$__key) ? \$__key : camel_case(str_replace(':', '_', \$__tag));
+                        \${\$__varName} = Statamic::tag(\$__tag)->params(\$__params)->fetch();
                     }
-                    \$__varName = is_string(\$__key) ? \$__key : camel_case(str_replace(':','_',\$__tag));
-                    \${\$__varName} = Statamic::tag(\$__tag)->params(\$__params)->fetch();
-                }
-            ?>";
-        });
+                ?>";
+            });
+        }
     }
 
     public function boot()


### PR DESCRIPTION
Lets you use the `Statamic::tag()` function in a more convenient way, for example:

```blade
@tags([
    'types' => ['taxonomy:types' => ['color:is' => 'red']],
    'collection:pages',
])
```

would give you two variables named `$types` and `$collectionPages` with the given statamic data.

