### PR TITLE
Add function that can traverse functions for data_get

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,36 @@
+name: phpunit
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.1, 8.2]
+        stability: [prefer-lowest, prefer-stable]
+
+    name: P${{ matrix.php }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,13 @@
         "php": "^8.0|^8.1|^8.2",
         "illuminate/support": "^9.0|^10.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5.10"
+    },
     "autoload": {
+        "files": [
+            "src/helpers.php"
+        ],
         "psr-4": {
             "Rapidez\\BladeDirectives\\": "src"
         }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./src/Tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/BladeDirectivesServiceProvider.php
+++ b/src/BladeDirectivesServiceProvider.php
@@ -55,7 +55,7 @@ class BladeDirectivesServiceProvider extends ServiceProvider
         });
 
         Blade::if('safeIsset', function ($target, $key = null) {
-            return boolval(data_get_value($target, $key, false));
+            return data_get_value($target, $key) !== null;
         });
     }
 

--- a/src/BladeDirectivesServiceProvider.php
+++ b/src/BladeDirectivesServiceProvider.php
@@ -53,6 +53,10 @@ class BladeDirectivesServiceProvider extends ServiceProvider
 <?php \$attributes ??= new \\Illuminate\\View\\ComponentAttributeBag; ?>
 <?php \$attributes = \$attributes->exceptProps($expression); ?>";
         });
+
+        Blade::if('safeIsset', function ($target, $key = null) {
+            return boolval(data_get_value($target, $key, false));
+        });
     }
 
     public function boot()

--- a/src/Tests/Unit/DataGetValueTest.php
+++ b/src/Tests/Unit/DataGetValueTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Rapidez\BladeDirectives\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class TestClass {
+    function __construct(private $_value)
+    {}
+
+    function value() {
+        return $this->_value;
+    }
+}
+
+class DataGetValueTest extends TestCase
+{
+    public function test_that_plain_array_returns_value()
+    {
+        $target = [
+            'foo' => [
+                'bar' => [
+                    'baz' => 'quux'
+                ]
+            ],
+        ];
+
+        $this->assertEquals('quux', data_get_value($target, 'foo.bar.baz'));
+    }
+
+    public function test_that_array_with_final_value_function_returns_value()
+    {
+        $target = [
+            'foo' => [
+                'bar' => [
+                    'baz' => [
+                        'value' => fn() => 'quux'
+                    ]
+                ]
+            ],
+        ];
+
+        $this->assertEquals('quux', data_get_value($target, 'foo.bar.baz.value'));
+    }
+
+    public function test_that_array_with_value_function_halfway_returns_value()
+    {
+        $target = [
+            'foo' => [
+                'bar' => [
+                    'value' => fn() => [
+                        'baz' =>'quux'
+                    ]
+                ]
+            ],
+        ];
+
+        $this->assertEquals('quux', data_get_value($target, 'foo.bar.value.baz'));
+    }
+
+    public function test_that_plain_stdclass_returns_value()
+    {
+        $target = (object) [
+            'foo' => [
+                'bar' => [
+                    'baz' => 'quux'
+                ]
+            ],
+        ];
+
+        $this->assertEquals('quux', data_get_value($target, 'foo.bar.baz'));
+    }
+
+    public function test_that_stdclass_with_final_value_function_returns_value()
+    {
+        $target = (object) [
+            'foo' => [
+                'bar' => [
+                    'baz' => [
+                        'value' => fn() => 'quux'
+                    ]
+                ]
+            ],
+        ];
+
+        $this->assertEquals('quux', data_get_value($target, 'foo.bar.baz.value'));
+    }
+
+    public function test_that_stdclass_with_value_function_halfway_returns_value()
+    {
+        $target = (object) [
+            'foo' => [
+                'bar' => [
+                    'value' => fn() => [
+                        'baz' =>'quux'
+                    ]
+                ]
+            ],
+        ];
+
+        $this->assertEquals('quux', data_get_value($target, 'foo.bar.value.baz'));
+    }
+
+    public function test_that_class_with_final_value_function_returns_value()
+    {
+        $target = (object) [
+            'foo' => [
+                'bar' => [
+                    'baz' => new TestClass('quux')
+                ]
+            ],
+        ];
+
+        $this->assertEquals('quux', data_get_value($target, 'foo.bar.baz.value'));
+    }
+
+    public function test_that_class_with_value_function_halfway_returns_value()
+    {
+        $target = (object) [
+            'foo' => [
+                'bar' => new TestClass([
+                    'baz' =>'quux'
+                ])
+            ],
+        ];
+
+        $this->assertEquals('quux', data_get_value($target, 'foo.bar.value.baz'));
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+if (! function_exists('data_get_value')) {
+    /**
+     * Get an item from an array or object using "dot" notation.
+     * Executing functions along the way as well.
+     *
+     * @see https://github.com/laravel/framework/blob/78fa6f2c758e929233889103e2f709d0017c7598/src/Illuminate/Collections/helpers.php#L46
+     * @param  mixed  $target
+     * @param  string|array|int|null  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    function data_get_value($target, $key, $default = null)
+    {
+        if (is_null($key)) {
+            return $target;
+        }
+
+        $key = is_array($key) ? $key : explode('.', $key);
+
+        foreach ($key as $i => $segment) {
+            unset($key[$i]);
+
+            if (is_null($segment)) {
+                return $target;
+            }
+
+            if ($segment === '*') {
+                if ($target instanceof Collection) {
+                    $target = $target->all();
+                } elseif (! is_iterable($target)) {
+                    return value($default);
+                }
+
+                $result = [];
+
+                foreach ($target as $item) {
+                    $result[] = data_get_value($item, $key);
+                }
+
+                return in_array('*', $key) ? Arr::collapse($result) : $result;
+            }
+
+            if (Arr::accessible($target) && Arr::exists($target, $segment)) {
+                $target = value($target[$segment]); // Result is wrapped in the value function
+            } elseif (is_object($target) && isset($target->{$segment})) {
+                $target = value($target->{$segment}); // Result is wrapped in the value function
+            } elseif (is_object($target) && method_exists($target, $segment)) {
+                $target = value($target->{$segment}()); // Added to execute methods if necessary
+            } else {
+                return value($default);
+            }
+        }
+
+        return $target;
+    }
+}


### PR DESCRIPTION
This is functionally and syntactically the same as https://laravel.com/docs/10.x/helpers#method-data-get

Usage outside of blade is 
```php
data_get_value($ArrayObjectOrClassInstance, 'dot.notation.to.value', 'default value')
```
If any of the items in de path to the value they will be executed without arguments.

In blade you can do
```blade
@safeIsset($ArrayObjectOrClassInstance, 'dot.notation.to.value')
@endIsset
```

Tests have been added tot test this functionality with functions in objects, arrays and Classes