### PR TITLE
Handle passing optionalDeep into optionalDeep

### DIFF
--- a/src/OptionalDeep.php
+++ b/src/OptionalDeep.php
@@ -20,7 +20,7 @@ class OptionalDeep implements ArrayAccess, IteratorAggregate, Countable, JsonSer
 
     public function __construct($value)
     {
-        $this->value = $value;
+        $this->value = $value instanceof static ? $value->get() : $value;
     }
 
     public function __get($key): static


### PR DESCRIPTION
Currently passing an optionaldeep into an optionaldeep would put the optionalDeep instance in value.
Thus calling $instance->get() would give you another optionalDeep class.

I think the implied way is how Laravel works with collections where passing a collection into a collection will collect the contained items instead of the collection itself