### PR TITLE
Allow attempted casting to boolean and array

### DIFF
--- a/src/OptionalDeep.php
+++ b/src/OptionalDeep.php
@@ -11,8 +11,6 @@ use IteratorAggregate;
 use JsonSerializable;
 use Traversable;
 
-use function PHPUnit\Framework\isEmpty;
-
 class OptionalDeep implements ArrayAccess, IteratorAggregate, Countable, JsonSerializable
 {
     use Macroable {


### PR DESCRIPTION
This adds the unimplemented RFCs as somewhat of a standard.
Magento actually uses these as well even though they're not official.

```
(array) optionalDeep([])
(bool) optionalDeep(false)
```

still does not work, as PHP does not support the magic getters.
However
```
optionalDeep([])->toArray();
optionalDeep([])->__toArray();
optionalDeep(true)->toBool();
optionalDeep(true)->__toBool();
```
does work