### PR TITLE
Use CanBeEscapedWhenCastToString

### DIFF
--- a/src/OptionalDeep.php
+++ b/src/OptionalDeep.php
@@ -5,13 +5,14 @@ namespace Rapidez\BladeDirectives;
 use ArrayAccess;
 use ArrayObject;
 use Countable;
+use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
 use JsonSerializable;
 use Traversable;
 
-class OptionalDeep implements ArrayAccess, IteratorAggregate, Countable, JsonSerializable
+class OptionalDeep implements ArrayAccess, IteratorAggregate, Countable, JsonSerializable, CanBeEscapedWhenCastToString
 {
     use Macroable {
         __call as macroCall;
@@ -203,6 +204,22 @@ class OptionalDeep implements ArrayAccess, IteratorAggregate, Countable, JsonSer
     public function jsonSerialize(): mixed
     {
         return $this->value;
+    }
+
+    // CanBeEscapedWhenCastToString interface
+    // This function gets called exclusively when passing props to a Blade component
+    // Here we hack it to return the full object rather than an escaped string when the value isn't stringable
+    public function escapeWhenCastingToString($escape = true)
+    {
+        if ($this->value instanceof Stringable
+            || is_string($this->value)
+            || is_scalar($this->value)
+            || $this->value === null
+        ) {
+            return e($this->value);
+        }
+
+        return $this;
     }
 
     public function __call($method, $parameters): mixed


### PR DESCRIPTION
This is essentially a hack to make laravel do what we want.

When you try to pass an OptionalDeep object as a prop to a component in Blade, it will try to use the `e(...)` helper if the `__toString()` function exists (which always exists here, because we override it), unless:
- The value is instanceof ComponentAttributeBag
- The value is not an object
- The value is already a string
- The value implements the CanBeEscapedWhenCastToString interface
See [this part of the CompilesComponents.php concern in laravel.](https://github.com/laravel/framework/blob/10.x/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php#L195)

Above function will get put directly into the compiled php files that blade spits out, and you can't avoid it here. [Interestingly, however, this does get skipped if you use an x-dynamic-component](https://github.com/laravel/framework/blob/10.x/src/Illuminate/View/Compilers/ComponentTagCompiler.php#L265).

It'll happen pretty often that we pass objects or arrays as props, which will then throw an error if it's been wrapped with an OptionalDeep.

Here I implement the CanBeEscapedWhenCastToString interface as the only viable option of the above, returning the value itself if it can't be turned into a string. This is currently *only* used in this one part of the CompilesComponents concern, so this works perfectly.

The only other approach would be hijacking [the e helper](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Support/helpers.php#L102), but you're forced to return a string there anyway for several reasons.

---

TL;DR: implement CanBeEscapedWhenCastToString to hack laravel into passing our props properly.