### PR TITLE
Fix method_exists check in OptionalDeep

### DIFF
--- a/src/OptionalDeep.php
+++ b/src/OptionalDeep.php
@@ -228,7 +228,7 @@ class OptionalDeep implements ArrayAccess, IteratorAggregate, Countable, JsonSer
             return $this->macroCall($method, $parameters);
         }
 
-        if (!is_object($this->value) || !is_string($this->value) || !method_exists($this->value, $method)) {
+        if (!is_object($this->value) || !method_exists($this->value, $method)) {
             if ($method == 'isNotEmpty') {
                 return $this->__isNotEmpty();
             }


### PR DESCRIPTION
Methods never actually got called through this, as nothing will ever be both a string and an object, failing this check.

Furthermore we don't actually need to check if it's a string---though `method_exists` accepts both an object and a string, the string is only for checking methods in classes when given a class name.