### PR TITLE
allow passing boolean to return directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The `@return` blade directive simply stops any further processing of the current
 
 ```blade
 @return
+{{-- Only return if collection is empty. --}}
+@return($collection->count() <= 0)
 ```
 
 ### @slotdefault

--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ The `@return` blade directive simply stops any further processing of the current
 
 ```blade
 @return
-{{-- Only return if collection is empty. --}}
-@return($collection->count() <= 0)
+```
+
+Or only when a condition is true:
+```blade
+@return($someConditionIsTrue)
 ```
 
 ### @slotdefault

--- a/src/BladeDirectivesServiceProvider.php
+++ b/src/BladeDirectivesServiceProvider.php
@@ -32,8 +32,8 @@ class BladeDirectivesServiceProvider extends ServiceProvider
             return "<?php echo (fn(\$markdown, \$html_input = 'escape') => Str::markdown(\$markdown ?? '', ['html_input' => \$html_input]))($expression); ?>";
         });
 
-        Blade::directive('return', function () {
-            return "<?php return; ?>";
+        Blade::directive('return', function ($expression) {
+            return "<?php if ((fn (\$return = true) => \$return)($expression)) {return;}; ?>";
         });
 
         Blade::directive('slots', function ($expression) {


### PR DESCRIPTION
This adds the ability to call the `@return` directive like
```blade
@return(!$collection->count())
```
instead of having to do
```blade
@if(!$collection->count())
    @return
@endif
```

Default behaviour is maintained.